### PR TITLE
Removed the "response" value from the JSON object

### DIFF
--- a/blueiris.py
+++ b/blueiris.py
@@ -112,7 +112,7 @@ class BlueIris:
         print "Connected to '%s'" % self.system_name
 
     def cmd(self, cmd, params=dict()):
-        args = {"session": self.session, "response": self.response, "cmd": cmd}
+        args = {"session": self.session, "cmd": cmd}
         args.update(params)
 
         # print self.url


### PR DESCRIPTION
Removed the "response" value from the JSON object sent to Blue Iris in the cmd function of the BlueIris object. According to the Blue Iris documentation (version 5) , a "response" value is not expected. (Only used when logging in) This might also be the case for version 4, I can't say.